### PR TITLE
Changed `modelIdentifier` in `deviceFamily` to `modelName`, so that the Simulator is properly assigned a deviceFamily.

### DIFF
--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -104,10 +104,10 @@
 
 - (UIDeviceFamily) deviceFamily
 {
-    NSString *modelIdentifier = [self modelIdentifier];
-    if ([modelIdentifier hasPrefix:@"iPhone"]) return UIDeviceFamilyiPhone;
-    if ([modelIdentifier hasPrefix:@"iPod"]) return UIDeviceFamilyiPod;
-    if ([modelIdentifier hasPrefix:@"iPad"]) return UIDeviceFamilyiPad;
+    NSString *modelName = [self modelName];
+    if ([modelName hasPrefix:@"iPhone"]) return UIDeviceFamilyiPhone;
+    if ([modelName hasPrefix:@"iPod"]) return UIDeviceFamilyiPod;
+    if ([modelName hasPrefix:@"iPad"]) return UIDeviceFamilyiPad;
     return UIDeviceFamilyUnknown;
 }
 


### PR DESCRIPTION
Right now, the Simulator returns UIDeviceFamilyUnknown because the suffix checker does not check for x86 and x86_64.

Running it through modelName properly populates those suffixes.
