### PR TITLE
Add iPhone SE support

### DIFF
--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -62,6 +62,7 @@
     if ([modelIdentifier isEqualToString:@"iPhone7,2"])    return @"iPhone 6";
     if ([modelIdentifier isEqualToString:@"iPhone8,1"])    return @"iPhone 6s";
     if ([modelIdentifier isEqualToString:@"iPhone8,2"])    return @"iPhone 6s Plus";
+    if ([modelIdentifier isEqualToString:@"iPhone8,4"])    return @"iPhone SE";
 
     // iPad http://theiphonewiki.com/wiki/IPad
     


### PR DESCRIPTION
Added iPhone SE model name support with model ID "iPhone8,4" mapped to "iPhone SE" model name according to https://www.theiphonewiki.com/wiki/Models