### PR TITLE
Support model except `AT&T` of iPhone7, iPhone7 Plus

### DIFF
--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -63,8 +63,10 @@
     if ([modelIdentifier isEqualToString:@"iPhone8,1"])    return @"iPhone 6s";
     if ([modelIdentifier isEqualToString:@"iPhone8,2"])    return @"iPhone 6s Plus";
     if ([modelIdentifier isEqualToString:@"iPhone8,4"])    return @"iPhone SE";
+    if ([modelIdentifier isEqualToString:@"iPhone9,1"])    return @"iPhone 7";
     if ([modelIdentifier isEqualToString:@"iPhone9,2"])    return @"iPhone 7 Plus";
     if ([modelIdentifier isEqualToString:@"iPhone9,3"])    return @"iPhone 7";
+    if ([modelIdentifier isEqualToString:@"iPhone9,4"])    return @"iPhone 7 Plus";
 
     // iPad http://theiphonewiki.com/wiki/IPad
 


### PR DESCRIPTION
Will support `iPhone9,1` and `iPhone9,4` except the `AT&T` model of `iPhone7` and `iPhone7 Plus`.

Reference http://www.everymac.com/systems/apple/iphone/index-iphone-specs.html
