### PR TITLE
Tweaks and Improvements

### DIFF
--- a/UIDevice-Hardware.h
+++ b/UIDevice-Hardware.h
@@ -29,6 +29,11 @@ typedef NS_ENUM(NSUInteger, UIDeviceFamily) {
 - (NSString *)modelName;
 
 /**
+ Returns a human-readable model name grouped by generation in the format of "iPhone 4S". Fallback of the the `modelIdentifier` value.
+ */
+- (NSString *)generationModelName;
+
+/**
  Returns the device family as a `UIDeviceFamily`
  */
 - (UIDeviceFamily)deviceFamily;

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -13,6 +13,8 @@
 
 - (NSString *)modelNameForModelIdentifier:(NSString *)modelIdentifier;
 
+- (NSString *)generationModelNameForModelIdentifier:(NSString *)modelIdentifier;
+
 @end
 
 @implementation UIDevice (Hardware)
@@ -131,6 +133,20 @@
     }
 
     return modelIdentifier;
+}
+
+- (NSString *)generationModelName
+{
+    return [self generationModelNameForModelIdentifier:[self modelIdentifier]];
+}
+
+- (NSString *)generationModelNameForModelIdentifier:(NSString *)modelIdentifier
+{
+    NSString *modelName = [self modelNameForModelIdentifier:modelIdentifier];
+    
+    NSString *generationModelName = [[modelName componentsSeparatedByString:@" ("] firstObject];
+    
+    return generationModelName;
 }
 
 - (UIDeviceFamily) deviceFamily

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -69,15 +69,19 @@
     if ([modelIdentifier isEqualToString:@"iPhone9,2"])    return @"iPhone 7 Plus (Global)";
     if ([modelIdentifier isEqualToString:@"iPhone9,3"])    return @"iPhone 7 (GSM)";
     if ([modelIdentifier isEqualToString:@"iPhone9,4"])    return @"iPhone 7 Plus (GSM)";
-    if ([modelIdentifier isEqualToString:@"iPhone10,1"])   return @"iPhone 8";
-    if ([modelIdentifier isEqualToString:@"iPhone10,2"])   return @"iPhone 8 Plus";
-    if ([modelIdentifier isEqualToString:@"iPhone10,3"])   return @"iPhone X";;
-    if ([modelIdentifier isEqualToString:@"iPhone10,4"])   return @"iPhone 8 (Global)";
-    if ([modelIdentifier isEqualToString:@"iPhone10,5"])   return @"iPhone 8 Plus (Global)";
-    if ([modelIdentifier isEqualToString:@"iPhone10,6"])   return @"iPhone X (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone10,1"])   return @"iPhone 8 (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone10,2"])   return @"iPhone 8 Plus (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone10,3"])   return @"iPhone X (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone10,4"])   return @"iPhone 8 (GSM)";
+    if ([modelIdentifier isEqualToString:@"iPhone10,5"])   return @"iPhone 8 Plus (GSM)";
+    if ([modelIdentifier isEqualToString:@"iPhone10,6"])   return @"iPhone X (GSM)";
     if ([modelIdentifier isEqualToString:@"iPhone11,2"])   return @"iPhone XS";
-    if ([modelIdentifier isEqualToString:@"iPhone11,4"])   return @"iPhone XS Max";
+    if ([modelIdentifier isEqualToString:@"iPhone11,4"])   return @"iPhone XS Max (China)";
+    if ([modelIdentifier isEqualToString:@"iPhone11,6"])   return @"iPhone XS Max";
     if ([modelIdentifier isEqualToString:@"iPhone11,8"])   return @"iPhone XR";
+    if ([modelIdentifier isEqualToString:@"iPhone12,1"])   return @"iPhone 11";
+    if ([modelIdentifier isEqualToString:@"iPhone12,3"])   return @"iPhone 11 Pro";
+    if ([modelIdentifier isEqualToString:@"iPhone12,5"])   return @"iPhone 11 Pro Max";
 
     // iPad https://www.theiphonewiki.com/wiki/List_of_iPads
 
@@ -102,6 +106,8 @@
     if ([modelIdentifier isEqualToString:@"iPad4,3"])      return @"iPad Air (China)";
     if ([modelIdentifier isEqualToString:@"iPad5,3"])      return @"iPad Air 2 (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad5,4"])      return @"iPad Air 2 (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad11,3"])     return @"iPad Air 3 (WiFi)";
+    if ([modelIdentifier isEqualToString:@"iPad11,4"])     return @"iPad Air 3 (Cellular)";
 
     // iPad Mini https://www.theiphonewiki.com/wiki/List_of_iPad_minis
 
@@ -116,6 +122,8 @@
     if ([modelIdentifier isEqualToString:@"iPad4,9"])      return @"iPad mini 3G (China)";
     if ([modelIdentifier isEqualToString:@"iPad5,1"])      return @"iPad mini 4G (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad5,2"])      return @"iPad mini 4G (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad11,1"])     return @"iPad mini 5G (Wi-Fi)";
+    if ([modelIdentifier isEqualToString:@"iPad11,2"])     return @"iPad mini 5G (Cellular)";
 
     // iPad Pro https://www.theiphonewiki.com/wiki/IPad_Pro
 
@@ -127,6 +135,14 @@
     if ([modelIdentifier isEqualToString:@"iPad7,2"])      return @"iPad Pro [12.9 inch] 2G (Cellular)";
     if ([modelIdentifier isEqualToString:@"iPad7,3"])      return @"iPad Pro [10.5 inch] 1G (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad7,4"])      return @"iPad Pro [10.5 inch] 1G (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad8,1"])      return @"iPad Pro [11 inch] 3G (Wi-Fi)";
+    if ([modelIdentifier isEqualToString:@"iPad8,2"])      return @"iPad Pro [11 inch] 3G (1TB, Wi-Fi)";
+    if ([modelIdentifier isEqualToString:@"iPad8,3"])      return @"iPad Pro [11 inch] 3G (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad8,4"])      return @"iPad Pro [11 inch] 3G (1TB, Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad8,5"])      return @"iPad Pro [12.9 inch] 3G (Wi-Fi)";
+    if ([modelIdentifier isEqualToString:@"iPad8,6"])      return @"iPad Pro [12.9 inch] 3G (1TB, Wi-Fi)";
+    if ([modelIdentifier isEqualToString:@"iPad8,7"])      return @"iPad Pro [12.9 inch] 3G (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad8,8"])      return @"iPad Pro [12.9 inch] 3G (1TB, Cellular)";
     
     // iPod https://www.theiphonewiki.com/wiki/List_of_iPod_touches
 
@@ -136,6 +152,7 @@
     if ([modelIdentifier isEqualToString:@"iPod4,1"])      return @"iPod touch 4G";
     if ([modelIdentifier isEqualToString:@"iPod5,1"])      return @"iPod touch 5G";
     if ([modelIdentifier isEqualToString:@"iPod7,1"])      return @"iPod touch 6G"; // as 6,1 was never released 7,1 is actually 6th generation
+    if ([modelIdentifier isEqualToString:@"iPod9,1"])      return @"iPod touch 7G";
 
     // Apple TV https://www.theiphonewiki.com/wiki/Apple_TV
 

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -65,8 +65,10 @@
     if ([modelIdentifier isEqualToString:@"iPhone8,1"])    return @"iPhone 6s";
     if ([modelIdentifier isEqualToString:@"iPhone8,2"])    return @"iPhone 6s Plus";
     if ([modelIdentifier isEqualToString:@"iPhone8,4"])    return @"iPhone SE";
-    if ([modelIdentifier isEqualToString:@"iPhone9,2"])    return @"iPhone 7 Plus";
-    if ([modelIdentifier isEqualToString:@"iPhone9,3"])    return @"iPhone 7";
+    if ([modelIdentifier isEqualToString:@"iPhone9,1"])    return @"iPhone 7 (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone9,2"])    return @"iPhone 7 Plus (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone9,3"])    return @"iPhone 7 (GSM)";
+    if ([modelIdentifier isEqualToString:@"iPhone9,4"])    return @"iPhone 7 Plus (GSM)";
 
     // iPad http://theiphonewiki.com/wiki/IPad
 
@@ -84,6 +86,7 @@
 
     if ([modelIdentifier isEqualToString:@"iPad4,1"])      return @"iPad Air (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad4,2"])      return @"iPad Air (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad4,3"])      return @"iPad Air (China)";
     if ([modelIdentifier isEqualToString:@"iPad5,3"])      return @"iPad Air 2 (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad5,4"])      return @"iPad Air 2 (Cellular)";
 

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -52,7 +52,7 @@
     if ([modelIdentifier isEqualToString:@"iPhone2,1"])    return @"iPhone 3GS";
     if ([modelIdentifier isEqualToString:@"iPhone3,1"])    return @"iPhone 4 (GSM)";
     if ([modelIdentifier isEqualToString:@"iPhone3,2"])    return @"iPhone 4 (GSM Rev A)";
-    if ([modelIdentifier isEqualToString:@"iPhone3,3"])    return @"iPhone 4 (CDMA)";
+    if ([modelIdentifier isEqualToString:@"iPhone3,3"])    return @"iPhone 4 (Global)";
     if ([modelIdentifier isEqualToString:@"iPhone4,1"])    return @"iPhone 4S";
     if ([modelIdentifier isEqualToString:@"iPhone5,1"])    return @"iPhone 5 (GSM)";
     if ([modelIdentifier isEqualToString:@"iPhone5,2"])    return @"iPhone 5 (Global)";
@@ -75,8 +75,8 @@
     if ([modelIdentifier isEqualToString:@"iPad1,1"])      return @"iPad 1G";
     if ([modelIdentifier isEqualToString:@"iPad2,1"])      return @"iPad 2 (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad2,2"])      return @"iPad 2 (GSM)";
-    if ([modelIdentifier isEqualToString:@"iPad2,3"])      return @"iPad 2 (CDMA)";
-    if ([modelIdentifier isEqualToString:@"iPad2,4"])      return @"iPad 2 (Rev A)";
+    if ([modelIdentifier isEqualToString:@"iPad2,3"])      return @"iPad 2 (Global)";
+    if ([modelIdentifier isEqualToString:@"iPad2,4"])      return @"iPad 2 (Wi-Fi Rev A)";
     if ([modelIdentifier isEqualToString:@"iPad3,1"])      return @"iPad 3 (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad3,2"])      return @"iPad 3 (GSM)";
     if ([modelIdentifier isEqualToString:@"iPad3,3"])      return @"iPad 3 (Global)";
@@ -97,10 +97,10 @@
     if ([modelIdentifier isEqualToString:@"iPad2,7"])      return @"iPad mini 1G (Global)";
     if ([modelIdentifier isEqualToString:@"iPad4,4"])      return @"iPad mini 2G (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad4,5"])      return @"iPad mini 2G (Cellular)";
-    if ([modelIdentifier isEqualToString:@"iPad4,6"])      return @"iPad mini 2G (Cellular)"; // TD-LTE model see https://support.apple.com/en-us/HT201471#iPad-mini2
+    if ([modelIdentifier isEqualToString:@"iPad4,6"])      return @"iPad mini 2G (China)"; // TD-LTE model see https://support.apple.com/en-us/HT201471#iPad-mini2
     if ([modelIdentifier isEqualToString:@"iPad4,7"])      return @"iPad mini 3G (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad4,8"])      return @"iPad mini 3G (Cellular)";
-    if ([modelIdentifier isEqualToString:@"iPad4,9"])      return @"iPad mini 3G (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad4,9"])      return @"iPad mini 3G (China)";
     if ([modelIdentifier isEqualToString:@"iPad5,1"])      return @"iPad mini 4G (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad5,2"])      return @"iPad mini 4G (Cellular)";
 
@@ -125,7 +125,7 @@
     if ([modelIdentifier isEqualToString:@"AppleTV1,1"])      return @"Apple TV 1G";
     if ([modelIdentifier isEqualToString:@"AppleTV2,1"])      return @"Apple TV 2G";
     if ([modelIdentifier isEqualToString:@"AppleTV3,1"])      return @"Apple TV 3G";
-    if ([modelIdentifier isEqualToString:@"AppleTV3,2"])      return @"Apple TV 3G"; // small, incremental update over 3,1
+    if ([modelIdentifier isEqualToString:@"AppleTV3,2"])      return @"Apple TV 3G (Rev A)"; // small, incremental update over 3,1
     if ([modelIdentifier isEqualToString:@"AppleTV5,3"])      return @"Apple TV 4G"; // as 4,1 was never released, 5,1 is actually 4th generation
 
     // Simulator

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -75,6 +75,9 @@
     if ([modelIdentifier isEqualToString:@"iPhone10,4"])   return @"iPhone 8 (Global)";
     if ([modelIdentifier isEqualToString:@"iPhone10,5"])   return @"iPhone 8 Plus (Global)";
     if ([modelIdentifier isEqualToString:@"iPhone10,6"])   return @"iPhone X (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone11,2"])   return @"iPhone XS";
+    if ([modelIdentifier isEqualToString:@"iPhone11,4"])   return @"iPhone XS Max";
+    if ([modelIdentifier isEqualToString:@"iPhone11,8"])   return @"iPhone XR";
 
     // iPad https://www.theiphonewiki.com/wiki/List_of_iPads
 
@@ -91,6 +94,8 @@
     if ([modelIdentifier isEqualToString:@"iPad3,6"])      return @"iPad 4 (Global)";
     if ([modelIdentifier isEqualToString:@"iPad6,11"])     return @"iPad 5 (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad6,12"])     return @"iPad 5 (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad7,5"])      return @"iPad 6 (WiFi)";
+    if ([modelIdentifier isEqualToString:@"iPad7,6"])      return @"iPad 6 (Cellular)";
 
     if ([modelIdentifier isEqualToString:@"iPad4,1"])      return @"iPad Air (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad4,2"])      return @"iPad Air (Cellular)";
@@ -139,6 +144,7 @@
     if ([modelIdentifier isEqualToString:@"AppleTV3,1"])      return @"Apple TV 3G";
     if ([modelIdentifier isEqualToString:@"AppleTV3,2"])      return @"Apple TV 3G (Rev A)"; // small, incremental update over 3,1
     if ([modelIdentifier isEqualToString:@"AppleTV5,3"])      return @"Apple TV 4G"; // as 4,1 was never released, 5,1 is actually 4th generation
+    if ([modelIdentifier isEqualToString:@"AppleTV6,2"])      return @"Apple TV 4K";
 
     // Simulator
     if ([modelIdentifier hasSuffix:@"86"] || [modelIdentifier isEqual:@"x86_64"])

--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -45,17 +45,17 @@
 
 - (NSString *)modelNameForModelIdentifier:(NSString *)modelIdentifier
 {
-    // iPhone http://theiphonewiki.com/wiki/IPhone
+    // iPhone https://www.theiphonewiki.com/wiki/List_of_iPhones
 
     if ([modelIdentifier isEqualToString:@"iPhone1,1"])    return @"iPhone 1G";
     if ([modelIdentifier isEqualToString:@"iPhone1,2"])    return @"iPhone 3G";
     if ([modelIdentifier isEqualToString:@"iPhone2,1"])    return @"iPhone 3GS";
     if ([modelIdentifier isEqualToString:@"iPhone3,1"])    return @"iPhone 4 (GSM)";
     if ([modelIdentifier isEqualToString:@"iPhone3,2"])    return @"iPhone 4 (GSM Rev A)";
-    if ([modelIdentifier isEqualToString:@"iPhone3,3"])    return @"iPhone 4 (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone3,3"])    return @"iPhone 4 (CDMA)";
     if ([modelIdentifier isEqualToString:@"iPhone4,1"])    return @"iPhone 4S";
     if ([modelIdentifier isEqualToString:@"iPhone5,1"])    return @"iPhone 5 (GSM)";
-    if ([modelIdentifier isEqualToString:@"iPhone5,2"])    return @"iPhone 5 (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone5,2"])    return @"iPhone 5 (CDMA)";
     if ([modelIdentifier isEqualToString:@"iPhone5,3"])    return @"iPhone 5c (GSM)";
     if ([modelIdentifier isEqualToString:@"iPhone5,4"])    return @"iPhone 5c (Global)";
     if ([modelIdentifier isEqualToString:@"iPhone6,1"])    return @"iPhone 5s (GSM)";
@@ -69,22 +69,28 @@
     if ([modelIdentifier isEqualToString:@"iPhone9,2"])    return @"iPhone 7 Plus (Global)";
     if ([modelIdentifier isEqualToString:@"iPhone9,3"])    return @"iPhone 7 (GSM)";
     if ([modelIdentifier isEqualToString:@"iPhone9,4"])    return @"iPhone 7 Plus (GSM)";
+    if ([modelIdentifier isEqualToString:@"iPhone10,1"])   return @"iPhone 8";
+    if ([modelIdentifier isEqualToString:@"iPhone10,2"])   return @"iPhone 8 Plus";
+    if ([modelIdentifier isEqualToString:@"iPhone10,3"])   return @"iPhone X";;
+    if ([modelIdentifier isEqualToString:@"iPhone10,4"])   return @"iPhone 8 (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone10,5"])   return @"iPhone 8 Plus (Global)";
+    if ([modelIdentifier isEqualToString:@"iPhone10,6"])   return @"iPhone X (Global)";
 
-    // iPad http://theiphonewiki.com/wiki/IPad
+    // iPad https://www.theiphonewiki.com/wiki/List_of_iPads
 
     if ([modelIdentifier isEqualToString:@"iPad1,1"])      return @"iPad 1G";
     if ([modelIdentifier isEqualToString:@"iPad2,1"])      return @"iPad 2 (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad2,2"])      return @"iPad 2 (GSM)";
-    if ([modelIdentifier isEqualToString:@"iPad2,3"])      return @"iPad 2 (Global)";
+    if ([modelIdentifier isEqualToString:@"iPad2,3"])      return @"iPad 2 (CDMA)";
     if ([modelIdentifier isEqualToString:@"iPad2,4"])      return @"iPad 2 (Wi-Fi Rev A)";
     if ([modelIdentifier isEqualToString:@"iPad3,1"])      return @"iPad 3 (Wi-Fi)";
-    if ([modelIdentifier isEqualToString:@"iPad3,2"])      return @"iPad 3 (GSM)";
-    if ([modelIdentifier isEqualToString:@"iPad3,3"])      return @"iPad 3 (Global)";
+    if ([modelIdentifier isEqualToString:@"iPad3,2"])      return @"iPad 3 (Global)";
+    if ([modelIdentifier isEqualToString:@"iPad3,3"])      return @"iPad 3 (GSM)";
     if ([modelIdentifier isEqualToString:@"iPad3,4"])      return @"iPad 4 (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad3,5"])      return @"iPad 4 (GSM)";
     if ([modelIdentifier isEqualToString:@"iPad3,6"])      return @"iPad 4 (Global)";
-    if ([modelIdentifier isEqualToString:@"iPad6,11"])     return @"iPad (5th gen) (Wi-Fi)";
-    if ([modelIdentifier isEqualToString:@"iPad6,12"])     return @"iPad (5th gen) (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad6,11"])     return @"iPad 5 (Wi-Fi)";
+    if ([modelIdentifier isEqualToString:@"iPad6,12"])     return @"iPad 5 (Cellular)";
 
     if ([modelIdentifier isEqualToString:@"iPad4,1"])      return @"iPad Air (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad4,2"])      return @"iPad Air (Cellular)";
@@ -92,7 +98,7 @@
     if ([modelIdentifier isEqualToString:@"iPad5,3"])      return @"iPad Air 2 (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad5,4"])      return @"iPad Air 2 (Cellular)";
 
-    // iPad Mini http://theiphonewiki.com/wiki/IPad_mini
+    // iPad Mini https://www.theiphonewiki.com/wiki/List_of_iPad_minis
 
     if ([modelIdentifier isEqualToString:@"iPad2,5"])      return @"iPad mini 1G (Wi-Fi)";
     if ([modelIdentifier isEqualToString:@"iPad2,6"])      return @"iPad mini 1G (GSM)";
@@ -108,12 +114,16 @@
 
     // iPad Pro https://www.theiphonewiki.com/wiki/IPad_Pro
 
-    if ([modelIdentifier isEqualToString:@"iPad6,3"])      return @"iPad Pro (9.7 inch) 1G (Wi-Fi)"; // http://pdadb.net/index.php?m=specs&id=9938&c=apple_ipad_pro_9.7-inch_a1673_wifi_32gb_apple_ipad_6,3
-    if ([modelIdentifier isEqualToString:@"iPad6,4"])      return @"iPad Pro (9.7 inch) 1G (Cellular)"; // http://pdadb.net/index.php?m=specs&id=9981&c=apple_ipad_pro_9.7-inch_a1675_td-lte_32gb_apple_ipad_6,4
-    if ([modelIdentifier isEqualToString:@"iPad6,7"])      return @"iPad Pro (12.9 inch) 1G (Wi-Fi)"; // http://pdadb.net/index.php?m=specs&id=8960&c=apple_ipad_pro_wifi_a1584_128gb
-    if ([modelIdentifier isEqualToString:@"iPad6,8"])      return @"iPad Pro (12.9 inch) 1G (Cellular)"; // http://pdadb.net/index.php?m=specs&id=8965&c=apple_ipad_pro_td-lte_a1652_32gb_apple_ipad_6,8
-
-    // iPod http://theiphonewiki.com/wiki/IPod
+    if ([modelIdentifier isEqualToString:@"iPad6,3"])      return @"iPad Pro [9.7 inch] 1G (Wi-Fi)"; // http://pdadb.net/index.php?m=specs&id=9938&c=apple_ipad_pro_9.7-inch_a1673_wifi_32gb_apple_ipad_6,3
+    if ([modelIdentifier isEqualToString:@"iPad6,4"])      return @"iPad Pro [9.7 inch] 1G (Cellular)"; // http://pdadb.net/index.php?m=specs&id=9981&c=apple_ipad_pro_9.7-inch_a1675_td-lte_32gb_apple_ipad_6,4
+    if ([modelIdentifier isEqualToString:@"iPad6,7"])      return @"iPad Pro [12.9 inch] 1G (Wi-Fi)"; // http://pdadb.net/index.php?m=specs&id=8960&c=apple_ipad_pro_wifi_a1584_128gb
+    if ([modelIdentifier isEqualToString:@"iPad6,8"])      return @"iPad Pro [12.9 inch] 1G (Cellular)"; // http://pdadb.net/index.php?m=specs&id=8965&c=apple_ipad_pro_td-lte_a1652_32gb_apple_ipad_6,8
+    if ([modelIdentifier isEqualToString:@"iPad7,1"])      return @"iPad Pro [12.9 inch] 2G (Wi-Fi)";
+    if ([modelIdentifier isEqualToString:@"iPad7,2"])      return @"iPad Pro [12.9 inch] 2G (Cellular)";
+    if ([modelIdentifier isEqualToString:@"iPad7,3"])      return @"iPad Pro [10.5 inch] 1G (Wi-Fi)";
+    if ([modelIdentifier isEqualToString:@"iPad7,4"])      return @"iPad Pro [10.5 inch] 1G (Cellular)";
+    
+    // iPod https://www.theiphonewiki.com/wiki/List_of_iPod_touches
 
     if ([modelIdentifier isEqualToString:@"iPod1,1"])      return @"iPod touch 1G";
     if ([modelIdentifier isEqualToString:@"iPod2,1"])      return @"iPod touch 2G";

--- a/UIDevice-Hardware.podspec
+++ b/UIDevice-Hardware.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = 'UIDevice-Hardware'
-  s.version      = '0.1.10'
-  s.license      = { :type => 'BSD' }
+  s.version      = '0.1.11'
+  s.license      = { :type => 'BSD', :file => 'LICENSE' }
   s.platform     = :ios
-  s.summary      = 'Category on UIDevice to distinguish between platforms and provide human-readable device names e.g. "iPad Mini 2G (Cellular)".'
-  s.homepage     = 'https://github.com/monospacecollective/UIDevice-Hardware'
-  s.authors      = { 'Erica Sadun' => 'erica@ericasadun.com', 'Eric Horacek' => 'eric@monospacecollective.com' }
-  s.source       = { :git => 'https://github.com/monospacecollective/UIDevice-Hardware.git', :tag => s.version.to_s }
+  s.summary      = 'Category on UIDevice to distinguish between platforms and provide human-readable device names e.g. "iPhone 8 Plus".'
+  s.homepage     = 'https://github.com/shebuka/UIDevice-Hardware'
+  s.authors      = { 'Erica Sadun' => 'erica@ericasadun.com', 'Eric Horacek' => 'eric@monospacecollective.com', 'Serge Golubenko' => 'sanctor.green@gmail.com' }
+  s.source       = { :git => 'https://github.com/shebuka/UIDevice-Hardware.git', :tag => s.version.to_s }
   s.source_files = 'UIDevice-Hardware.{h,m}'
   s.requires_arc = true
 end

--- a/UIDevice-Hardware.podspec
+++ b/UIDevice-Hardware.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name         = 'UIDevice-Hardware'
-  s.version      = '0.1.11'
+  s.version      = '0.1.12'
   s.license      = { :type => 'BSD', :file => 'LICENSE' }
   s.platform     = :ios
-  s.summary      = 'Category on UIDevice to distinguish between platforms and provide human-readable device names e.g. "iPhone 8 Plus".'
+  s.summary      = 'Category on UIDevice to distinguish between platforms and provide human-readable device names e.g. "iPhone 11 Pro".'
   s.homepage     = 'https://github.com/shebuka/UIDevice-Hardware'
   s.authors      = { 'Erica Sadun' => 'erica@ericasadun.com', 'Eric Horacek' => 'eric@monospacecollective.com', 'Serge Golubenko' => 'sanctor.green@gmail.com' }
   s.source       = { :git => 'https://github.com/shebuka/UIDevice-Hardware.git', :tag => s.version.to_s }


### PR DESCRIPTION
- generationModelName treats device variants as same device, so iPad Air
  (Wi-Fi) and iPad Air (Cellular) are both returned as iPad Air.
- Added missed identifiers of iPhone 7 (Global), iPhone 7 Plus (GSM) and
  iPad Air (China).
- Tweaked some model names to better represent connectivity capacities:
  Global is a GSM/CDMA[/LTE] device;
  China is a GSM/TD-LTE device.
