### PR TITLE
Removed extension to avoid warnings

### DIFF
--- a/UIDevice-Hardware.m
+++ b/UIDevice-Hardware.m
@@ -9,12 +9,6 @@
 #include <sys/sysctl.h>
 #import "UIDevice-Hardware.h"
 
-@interface UIDevice (Hardward)
-
-- (NSString *)modelNameForModelIdentifier:(NSString *)modelIdentifier;
-
-@end
-
 @implementation UIDevice (Hardware)
 
 - (NSString *)getSysInfoByName:(char *)typeSpecifier


### PR DESCRIPTION
Methods do not require declarations in extensions anymore. Somehow this creates a warning in Xcode 10 which is removed by removing the extension altogether.